### PR TITLE
feat: Add support for HTTP proxy

### DIFF
--- a/packages/enterprise-search/package.json
+++ b/packages/enterprise-search/package.json
@@ -46,6 +46,7 @@
     "dotenv": "^15.0.0",
     "license-checker": "^25.0.1",
     "nanoid": "^3.2.0",
+    "proxy": "^1.0.2",
     "tap": "^15.1.6",
     "ts-node": "^10.4.0",
     "ts-standard": "^11.0.0",

--- a/packages/enterprise-search/package.json
+++ b/packages/enterprise-search/package.json
@@ -46,7 +46,6 @@
     "dotenv": "^15.0.0",
     "license-checker": "^25.0.1",
     "nanoid": "^3.2.0",
-    "proxy": "^1.0.2",
     "tap": "^15.1.6",
     "ts-node": "^10.4.0",
     "ts-standard": "^11.0.0",

--- a/packages/enterprise-search/src/index.ts
+++ b/packages/enterprise-search/src/index.ts
@@ -20,6 +20,7 @@
 import {
   CloudConnectionPool,
   Diagnostic,
+  HttpConnection,
   UndiciConnection
 } from '@elastic/transport'
 import EnterpriseSearchClient from './EnterpriseSearchClient'
@@ -50,11 +51,12 @@ export default class Client {
       this[kConnectionPool] = internal.connectionPool
     } else {
       this[kConnectionPool] = new CloudConnectionPool({
-        Connection: UndiciConnection,
+        Connection: opts.proxy === undefined ? UndiciConnection : HttpConnection,
         diagnostic: this.diagnostic,
         tls: opts.url.startsWith('https://')
           ? { secureProtocol: 'TLSv1_2_method' }
-          : undefined
+          : undefined,
+        proxy: opts.proxy
       })
       this[kConnectionPool].addConnection(opts.url)
     }

--- a/packages/enterprise-search/src/utils.ts
+++ b/packages/enterprise-search/src/utils.ts
@@ -19,6 +19,7 @@
 
 import {
   CloudConnectionPool,
+  ConnectionPoolOptions,
   Diagnostic
 } from '@elastic/transport'
 
@@ -36,12 +37,16 @@ export interface InternalOptions {
   diagnostic: Diagnostic
 }
 
-export interface ClientOptions extends AuthOptions {
+export interface ClientOptions extends AuthOptions, ProxyOptions {
   url: string
 }
 
 export interface AuthOptions {
   auth: BasicAuth | BearerAuth
+}
+
+export interface ProxyOptions {
+  proxy?: ConnectionPoolOptions['proxy']
 }
 
 export function isBearerAuth (obj: any): obj is BearerAuth {

--- a/packages/enterprise-search/test/integration/enterprise/index.test.ts
+++ b/packages/enterprise-search/test/integration/enterprise/index.test.ts
@@ -17,24 +17,12 @@
  * under the License.
  */
 
-import proxy from 'proxy';
-import * as http from 'http';
 import { test } from 'tap'
 import { Client } from '../../..'
-import { AddressInfo } from 'net';
 
 const url = process.env.ENTERPRISE_SEARCH_URL ?? 'http://localhost:3002'
 const username = process.env.ELASTIC_ENTERPRISE_USER ?? 'elastic'
 const password = process.env.ELASTIC_ENTERPRISE_PASSWORD ?? 'changeme'
-
-const createProxy = (): Promise<http.Server> => {
-  return new Promise((resolve, reject) => {
-    const server = proxy(http.createServer())
-    server.listen(0, '127.0.0.1', () => {
-      resolve(server)
-    })
-  })
-}
 
 test('getHealth', async t => {
   const client = new Client({
@@ -47,22 +35,6 @@ test('getHealth', async t => {
   t.type(response.cluster_uuid, 'string')
 
   await client.close()
-})
-
-test('getHealth Proxy', async t => {
-  const proxy = await createProxy();
-  const client = new Client({
-    url,
-    auth: { username, password },
-    proxy: `http://${(proxy.address() as AddressInfo).address}:${(proxy.address() as AddressInfo).port}`,
-  })
-
-  const response = await client.enterprise.getHealth()
-  t.type(response.name, 'string')
-  t.type(response.cluster_uuid, 'string')
-
-  await client.close()
-  await proxy.close();
 })
 
 test('getReadOnly', async t => {


### PR DESCRIPTION
As the title says this adds the possibility to specify a HTTP(S) proxy when accessing Enterprise Search API endpoints