### PR TITLE
Fix imports in index.d.ts

### DIFF
--- a/packages/enterprise-search/index.d.ts
+++ b/packages/enterprise-search/index.d.ts
@@ -19,9 +19,9 @@
 
 import Client from './lib'
 
-export type { ClientOptions, AuthOptions } from './lib/types'
-export type { AppTypes } from './src/AppSearchClient'
-export type { EnterpriseTypes } from './src/EnterpriseSearchClient'
-export type { WorkplaceTypes } from './src/WorkplaceSearchClient'
+export type { ClientOptions, AuthOptions } from './lib/utils'
+export type { AppTypes } from './lib/AppSearchClient'
+export type { EnterpriseTypes } from './lib/EnterpriseSearchClient'
+export type { WorkplaceTypes } from './lib/WorkplaceSearchClient'
 export * from '@elastic/transport'
 export { Client }


### PR DESCRIPTION
Closes https://github.com/elastic/enterprise-search-js/issues/16 The imports were pointing to `src` and non-existent `lib/types` (instead of `lib` and `lib/utils`).

Tested by building `packages/enterprise-search` locally and running `tsc` and `ts-node` on this file:

```ts
import { Client } from '.';
console.log(Client);
```