### PR TITLE
chore: clean-up work

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/universal.yml
+++ b/.github/workflows/universal.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/packages/enterprise-search-universal/package.json
+++ b/packages/enterprise-search-universal/package.json
@@ -40,7 +40,8 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@types/node": "^17.0.23",
+    "@types/node": "^16.11.7",
+    "@types/semver": "^7.3.13",
     "@types/tape": "^4.13.2",
     "airtap": "^4.0.4",
     "airtap-playwright": "^1.0.1",

--- a/packages/enterprise-search-universal/test/node/basic.test.ts
+++ b/packages/enterprise-search-universal/test/node/basic.test.ts
@@ -20,8 +20,16 @@
 import 'cross-fetch/polyfill'
 import test from 'tape'
 import * as http from 'http'
-import { AbortController } from 'node-abort-controller'
+import { parse } from 'semver';
 import { Client } from '../../src/client'
+
+let AbortController = global.AbortController;
+if (parse(process.version)!.major! < 16) {
+  let {
+    AbortController: polyFillAbortController,
+  } = require("node-abort-controller");
+  AbortController = polyFillAbortController;
+}
 
 type ServerHandler = (req: http.IncomingMessage, res: http.ServerResponse) => void
 function buildServer (handler: ServerHandler): Promise<http.Server> {


### PR DESCRIPTION
- Updated the node matrix for CI to use v18 instead of v17 of node. v18 is now LTS and odd versions are not recommended.
- Updated the universal client unit tests to conditionally import `AbortController` only when using node v14. It is included in node v16 and I was seeing test failures on macOS and linux when using node v16.
