### PR TITLE
chore: introduce codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# GitHub CODEOWNERS definition
+# Identify which groups will be pinged by changes to different parts of the codebase.
+# For more info, see https://help.github.com/articles/about-codeowners/
+
+* @elastic/clients-team
+* @elastic/enterprise-search-frontend


### PR DESCRIPTION
Introducing codeowners file with clients and enterprise-search frontend team as initial owners.