### PR TITLE
Update dependencies for types

### DIFF
--- a/packages/enterprise-search-universal/package.json
+++ b/packages/enterprise-search-universal/package.json
@@ -40,7 +40,7 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@types/node": "^16.11.7",
+    "@types/node": "*",
     "@types/semver": "^7.3.13",
     "@types/tape": "^4.13.2",
     "airtap": "^4.0.4",

--- a/packages/enterprise-search/package.json
+++ b/packages/enterprise-search/package.json
@@ -40,7 +40,7 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@types/node": "^17.0.14",
+    "@types/node": "*",
     "@types/qs": "^6.9.7",
     "@types/tap": "^15.0.5",
     "dotenv": "^15.0.0",

--- a/packages/enterprise-search/tsconfig.json
+++ b/packages/enterprise-search/tsconfig.json
@@ -21,7 +21,8 @@
     "importHelpers": true,
     "outDir": "lib",
     "lib": [
-      "esnext"
+      "esnext",
+      "dom"
     ]
   },
   "formatCodeOptions": {


### PR DESCRIPTION
Ran into an issue when building the packages for release with `tsc`. Specifically [this issue](https://github.com/microsoft/TypeScript/issues/51567) which is resolved by setting `@types/node` to `*`. Also ran into an issue with undici requiring the `dom` library for the `MessagePort` type.

With these changes and a refreshed `node_modules` and `package-lock.json` I can run `npm run build` successfully for both packages.