### PR TITLE
Example auth usage with private key

### DIFF
--- a/packages/enterprise-search/docs/app-search-api.asciidoc
+++ b/packages/enterprise-search/docs/app-search-api.asciidoc
@@ -31,6 +31,21 @@ See <<quickstart-client>> for details on initializing the client.
 Note that App Search also has its own application-specific API keys and tokens.
 Refer to <<authentication>> for more information and relevant links.
 
+Example of initializing the client using an App Search API private key for authorization.
+
+[source,javascript]
+----
+const { Client } = require('@elastic/enterprise-search')
+const client = new Client({
+  url: 'https://d84b2890a1d7f30699b04c7b1d6930f8.ent-search.europe-west1.gcp.cloud.es.io',
+  auth: {
+    token: 'private-abcdef17grbg9jg8m1zam9q'
+  }
+})
+----
+
+Once instantiated you can use the `client` object to make API requests to App Search.
+
 [discrete#app-search-api-initializing-api-key]
 ==== API key privileges
 


### PR DESCRIPTION
When experimenting with the node client, I didn't see a specific example of how to authenticate using an App Search API private key. Hope this helps.
