### PR TITLE
fix: app.putSchema() schema property does not match usage #41

### DIFF
--- a/packages/enterprise-search/src/api/app/types.ts
+++ b/packages/enterprise-search/src/api/app/types.ts
@@ -2211,7 +2211,7 @@ export interface PutSchemaRequest {
    */
   engine_name: string
   schema?: {
-    [k: string]: [k: string]| unknown
+    [k: string]: string
   }
 }
 

--- a/packages/enterprise-search/src/api/app/types.ts
+++ b/packages/enterprise-search/src/api/app/types.ts
@@ -2211,9 +2211,7 @@ export interface PutSchemaRequest {
    */
   engine_name: string
   schema?: {
-    [k: string]: {
-      [k: string]: unknown
-    }
+    [k: string]: [k: string]| unknown
   }
 }
 


### PR DESCRIPTION
fix: app.putSchema() schema param types do not match the documentation [#41](https://github.com/elastic/enterprise-search-js/issues/41)

### PROBLEM
developers currently getting typescript compilation errors when using the `putSchema` method (in accordance with the docs), and are having to add `//ts-ignore` to suppress the error. (see issue #41)

### CHANGES
- updated `packages/enterprise-search/src/api/app/types.ts`
**PutSchemaRequest** `schema` property
