### PR TITLE
bump to 8.11 for release

### DIFF
--- a/packages/enterprise-search-universal/package.json
+++ b/packages/enterprise-search-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/enterprise-search-universal",
-  "version": "8.7.0",
+  "version": "8.11.0",
   "description": "Official universal client for Elastic App Search and Workplace Search.",
   "main": "lib/client.js",
   "types": "lib/client.d.ts",

--- a/packages/enterprise-search/package.json
+++ b/packages/enterprise-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/enterprise-search",
-  "version": "8.7.0",
+  "version": "8.11.0",
   "description": "Official Node.js client for Elastic Enterprise Search, App Search, and Workplace Search.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Bump version for 8.11 release.

As of right now I'm not aware of any client updates. I did regenerate the client code, but nothing was updated. I'm verifying thats the expected result.
