### PR TITLE
Add missing 8.6 APIs from the spec

### DIFF
--- a/packages/enterprise-search/docs/overview.asciidoc
+++ b/packages/enterprise-search/docs/overview.asciidoc
@@ -31,7 +31,7 @@ The syntax should look like this:
 ----
 {
   "dependencies": {
-    "@elastic/enterprise-search": "^8.6.0"
+    "@elastic/enterprise-search": "^8.6.1"
   }
 }
 ----

--- a/packages/enterprise-search/docs/release-notes/8-6-1.asciidoc
+++ b/packages/enterprise-search/docs/release-notes/8-6-1.asciidoc
@@ -1,0 +1,4 @@
+[#release-notes-8-6-1]
+=== 8.6.1 release notes
+
+* Updated APIs to include missing changes from the 8.6 specification.

--- a/packages/enterprise-search/docs/release-notes/index.asciidoc
+++ b/packages/enterprise-search/docs/release-notes/index.asciidoc
@@ -1,7 +1,9 @@
 [#release-notes]
 == Release Notes
 
+* <<release-notes-8-6-1, 8.6.1 Release Notes>>
 * <<release-notes-8-6-0, 8.6.0 Release Notes>>
  
 
+include::8-6-1.asciidoc[]
 include::8-6-0.asciidoc[]

--- a/packages/enterprise-search/package.json
+++ b/packages/enterprise-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/enterprise-search",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "description": "Official Node.js client for Elastic Enterprise Search, App Search, and Workplace Search.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/enterprise-search/src/api/app/api.ts
+++ b/packages/enterprise-search/src/api/app/api.ts
@@ -879,6 +879,20 @@ export default class API {
     }, options)
   }
 
+  async searchEsSearch_v0 (this: That, params: T.SearchEsSearchV0Request, options?: TransportRequestOptions): Promise<T.SearchEsSearchV0Response> {
+    const {
+      engine_name,
+      body,
+      ...querystring
+    } = params ?? {}
+    return await this.transport.request<T.SearchEsSearchV0Response>({
+      method: 'POST',
+      path: `/api/as/v0/engines/${engine_name}/elasticsearch/_search`,
+      querystring,
+      body: body
+    }, options)
+  }
+
   async searchEsSearch (this: That, params: T.SearchEsSearchRequest, options?: TransportRequestOptions): Promise<T.SearchEsSearchResponse> {
     const {
       engine_name,
@@ -887,7 +901,7 @@ export default class API {
     } = params ?? {}
     return await this.transport.request<T.SearchEsSearchResponse>({
       method: 'POST',
-      path: `/api/as/v0/engines/${engine_name}/elasticsearch/_search`,
+      path: `/api/as/v1/engines/${engine_name}/elasticsearch/_search`,
       querystring,
       body: body
     }, options)
@@ -961,6 +975,34 @@ export default class API {
     }, options)
   }
 
+  async multiSearch (this: That, params: T.MultiSearchRequest, options?: TransportRequestOptions): Promise<T.MultiSearchResponse> {
+    const {
+      engine_name,
+      body,
+      ...querystring
+    } = params ?? {}
+    return await this.transport.request<T.MultiSearchResponse>({
+      method: 'POST',
+      path: `/api/as/v1/engines/${engine_name}/multi_search`,
+      querystring,
+      body: body
+    }, options)
+  }
+
+  async search_explain_v0 (this: That, params: T.SearchExplainV0Request, options?: TransportRequestOptions): Promise<T.SearchExplainV0Response> {
+    const {
+      engine_name,
+      body,
+      ...querystring
+    } = params ?? {}
+    return await this.transport.request<T.SearchExplainV0Response>({
+      method: 'POST',
+      path: `/api/as/v0/engines/${engine_name}/search_explain`,
+      querystring,
+      body: body
+    }, options)
+  }
+
   async search_explain (this: That, params: T.SearchExplainRequest, options?: TransportRequestOptions): Promise<T.SearchExplainResponse> {
     const {
       engine_name,
@@ -969,7 +1011,7 @@ export default class API {
     } = params ?? {}
     return await this.transport.request<T.SearchExplainResponse>({
       method: 'POST',
-      path: `/api/as/v0/engines/${engine_name}/search_explain`,
+      path: `/api/as/v1/engines/${engine_name}/search_explain`,
       querystring,
       body: body
     }, options)

--- a/packages/enterprise-search/src/api/app/types.ts
+++ b/packages/enterprise-search/src/api/app/types.ts
@@ -84,7 +84,8 @@ export interface ListAdaptiveRelevanceSuggestionsRequest {
       size?: number
     }
     filters?: {
-      [k: string]: unknown
+      status?: Array<'pending' | 'applied' | 'automated' | 'rejected' | 'disabled'>
+      type?: 'curation'
     }
   }
 }
@@ -133,7 +134,8 @@ export interface GetAdaptiveRelevanceSuggestionsRequest {
       size?: number
     }
     filters?: {
-      [k: string]: unknown
+      status?: Array<'pending' | 'applied' | 'automated' | 'rejected' | 'disabled'>
+      type?: 'curation'
     }
   }
 }
@@ -166,7 +168,8 @@ export interface GetTopClicksAnalyticsRequest {
     }
     | {
       date: {
-        [k: string]: unknown
+        to: string
+        from: string
       }
     }
     | {
@@ -175,7 +178,8 @@ export interface GetTopClicksAnalyticsRequest {
       }
       | {
         date: {
-          [k: string]: unknown
+          to: string
+          from: string
         }
       }>
     }
@@ -216,7 +220,8 @@ export interface GetCountAnalyticsRequest {
     }
     | {
       date: {
-        [k: string]: unknown
+        to: string
+        from: string
       }
     }
     | {
@@ -231,7 +236,8 @@ export interface GetCountAnalyticsRequest {
       }
       | {
         date: {
-          [k: string]: unknown
+          to: string
+          from: string
         }
       }>
     }
@@ -266,7 +272,8 @@ export interface GetTopQueriesAnalyticsRequest {
     }
     | {
       date: {
-        [k: string]: unknown
+        to: string
+        from: string
       }
     }
     | {
@@ -281,7 +288,8 @@ export interface GetTopQueriesAnalyticsRequest {
       }
       | {
         date: {
-          [k: string]: unknown
+          to: string
+          from: string
         }
       }>
     }
@@ -339,9 +347,7 @@ export interface GetCrawlerUrlExtractionResultResponse {
     }
     extraction: {
       content_hash: string
-      content_hash_fields: Array<{
-        [k: string]: unknown
-      }>
+      content_hash_fields: string[]
       content_fields: {}
       meta_tag_warnings: Array<{
         name: string
@@ -367,11 +373,13 @@ export interface CreateCrawlerCrawlRequestRequest {
    */
   engine_name: string
   body?: {
-    max_crawl_depth?: number
-    sitemap_discovery_disabled?: boolean
-    domain_allowlist?: string[]
-    seed_urls?: string[]
-    sitemap_urls?: string[]
+    overrides: {
+      max_crawl_depth?: number
+      sitemap_discovery_disabled?: boolean
+      domain_allowlist?: string[]
+      seed_urls?: string[]
+      sitemap_urls?: string[]
+    }
   }
 }
 
@@ -1268,6 +1276,9 @@ export interface CreateCrawlerProcessCrawlResponse {
   dry_run?: boolean
   total_url_count?: number
   denied_url_count?: number
+  /**
+   * @minItems 0
+   */
   domains?: string[]
   process_all_domains?: boolean
   created_at?: string
@@ -1306,6 +1317,9 @@ export interface ListCrawlerProcessCrawlsResponse {
     dry_run?: boolean
     total_url_count?: number
     denied_url_count?: number
+    /**
+     * @minItems 0
+     */
     domains?: string[]
     process_all_domains?: boolean
     created_at?: string
@@ -1330,6 +1344,9 @@ export interface GetCrawlerProcessCrawlResponse {
   dry_run?: boolean
   total_url_count?: number
   denied_url_count?: number
+  /**
+   * @minItems 0
+   */
   domains?: string[]
   process_all_domains?: boolean
   created_at?: string
@@ -1705,7 +1722,10 @@ export interface ListCurationsResponse {
      */
     hidden?: string[]
     suggestion?: {
-      [k: string]: unknown
+      query?: string
+      status?: 'pending' | 'applied' | 'automated' | 'rejected' | 'disabled'
+      updated_at?: string
+      created_at?: string
     }
   }>
 }
@@ -1730,7 +1750,10 @@ export interface CreateCurationRequest {
      */
     hidden?: string[]
     suggestion?: {
-      [k: string]: unknown
+      query?: string
+      status?: 'pending' | 'applied' | 'automated' | 'rejected' | 'disabled'
+      updated_at?: string
+      created_at?: string
     }
   }
 }
@@ -1765,7 +1788,10 @@ export interface GetCurationResponse {
    */
   hidden?: string[]
   suggestion?: {
-    [k: string]: unknown
+    query?: string
+    status?: 'pending' | 'applied' | 'automated' | 'rejected' | 'disabled'
+    updated_at?: string
+    created_at?: string
   }
 }
 
@@ -1793,7 +1819,10 @@ export interface PutCurationRequest {
      */
     hidden?: string[]
     suggestion?: {
-      [k: string]: unknown
+      query?: string
+      status?: 'pending' | 'applied' | 'automated' | 'rejected' | 'disabled'
+      updated_at?: string
+      created_at?: string
     }
   }
 }
@@ -2066,19 +2095,70 @@ export interface AddMetaEngineSourceResponse {
   }
 }
 
+export interface SearchEsSearchV0Request {
+  /**
+   * Name of the engine
+   */
+  engine_name: string
+  /**
+   * Query parameters to be passed to Elasticsearch _search API
+   */
+  es_search_query_params?: {
+    [k: string]: unknown
+  }
+  /**
+   * The search query associated with this request when recording search analytics
+   */
+  'X-Enterprise-Search-Analytics'?: {
+    [k: string]: unknown
+  }
+  /**
+   * Analytics tags to be applied with this search request
+   */
+  'X-Enterprise-Search-Analytics-Tags'?: {
+    [k: string]: unknown
+  }
+  /**
+   * The Elasticsearch token API
+   */
+  Authorization: {
+    [k: string]: unknown
+  }
+  body?: {}
+}
+
+export type SearchEsSearchV0Response = Record<string, unknown>
+
 export interface SearchEsSearchRequest {
   /**
    * Name of the engine
    */
   engine_name: string
-  body?: {
-    request: {
-      [k: string]: unknown
-    }
-    analytics?: {
-      [k: string]: unknown
-    }
+  /**
+   * Query parameters to be passed to Elasticsearch _search API
+   */
+  es_search_query_params?: {
+    [k: string]: unknown
   }
+  /**
+   * The search query associated with this request when recording search analytics
+   */
+  'X-Enterprise-Search-Analytics'?: {
+    [k: string]: unknown
+  }
+  /**
+   * Analytics tags to be applied with this search request
+   */
+  'X-Enterprise-Search-Analytics-Tags'?: {
+    [k: string]: unknown
+  }
+  /**
+   * The Elasticsearch token API
+   */
+  Authorization: {
+    [k: string]: unknown
+  }
+  body?: {}
 }
 
 export type SearchEsSearchResponse = Record<string, unknown>
@@ -2091,9 +2171,8 @@ export interface GetApiLogsRequest {
   body?: {
     filters: {
       date: {
-        from?: string
-        to?: string
-        required?: ['from', 'to']
+        from: string
+        to: string
       }
       status?: number
       method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
@@ -2120,9 +2199,8 @@ export interface GetApiLogsResponse {
     query?: string
     filters?: {
       date: {
-        from?: string
-        to?: string
-        required?: ['from', 'to']
+        from: string
+        to: string
       }
       status?: number
       method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
@@ -2248,6 +2326,126 @@ export interface SearchResponse {
   results: Array<{}>
 }
 
+export interface MultiSearchRequest {
+  /**
+   * Name of the engine
+   */
+  engine_name: string
+  body?: {
+    queries: Array<{
+      query: string
+      analytics?: {}
+      boost?: {}
+      facets?: {}
+      filters?: {}
+      group?: {}
+      page?: {
+        current?: number
+        size?: number
+      }
+      result_fields?: {}
+      search_fields?: {
+        [k: string]: {
+          weight?: number
+        }
+      }
+      sort?: Array<{
+        [k: string]:
+        | ('asc' | 'desc')
+        | {
+          center?:
+          | string
+          | Array<{
+            [k: string]: unknown
+          }>
+          order?: 'asc' | 'desc'
+          mode?: 'min' | 'max' | 'median' | 'avg'
+        }
+      }>
+    }>
+  }
+}
+
+export type MultiSearchResponse = Array<{
+  meta: {
+    page: {
+      current: number
+      total_pages: number
+      total_results: number
+      size: number
+    }
+  } & {
+    alerts: string[]
+    warnings: string[]
+    precision?: number
+    engine: {
+      name?: string
+      /**
+       * Engine type
+       */
+      type?: 'meta' | 'default'
+    }
+    request_id?: string
+  }
+  results: Array<{}>
+}>
+
+export interface SearchExplainV0Request {
+  /**
+   * Name of the engine
+   */
+  engine_name: string
+  body?: {
+    query: string
+    analytics?: {}
+    boost?: {}
+    facets?: {}
+    filters?: {}
+    group?: {}
+    page?: {
+      current?: number
+      size?: number
+    }
+    result_fields?: {}
+    search_fields?: {
+      [k: string]: {
+        weight?: number
+      }
+    }
+    sort?: Array<{
+      [k: string]:
+      | ('asc' | 'desc')
+      | {
+        center?:
+        | string
+        | Array<{
+          [k: string]: unknown
+        }>
+        order?: 'asc' | 'desc'
+        mode?: 'min' | 'max' | 'median' | 'avg'
+      }
+    }>
+  }
+}
+
+export interface SearchExplainV0Response {
+  meta: {
+    alerts: string[]
+    warnings: string[]
+    precision?: number
+    engine: {
+      name?: string
+      /**
+       * Engine type
+       */
+      type?: 'meta' | 'default'
+    }
+    request_id?: string
+  }
+  query_string: string
+  query_body: {}
+}
+
 export interface SearchExplainRequest {
   /**
    * Name of the engine
@@ -2320,6 +2518,7 @@ export interface GetSearchSettingsResponse {
   }
   result_fields?: {}
   precision?: number
+  precision_enabled?: boolean
 }
 
 export interface PutSearchSettingsRequest {
@@ -2336,6 +2535,7 @@ export interface PutSearchSettingsRequest {
     }
     result_fields?: {}
     precision?: number
+    precision_enabled?: boolean
   }
 }
 
@@ -2348,6 +2548,7 @@ export interface PutSearchSettingsResponse {
   }
   result_fields?: {}
   precision?: number
+  precision_enabled?: boolean
 }
 
 export interface ResetSearchSettingsRequest {
@@ -2366,6 +2567,7 @@ export interface ResetSearchSettingsResponse {
   }
   result_fields?: {}
   precision?: number
+  precision_enabled?: boolean
 }
 
 export interface ListSynonymSetsRequest {

--- a/packages/enterprise-search/src/api/enterprise/api.ts
+++ b/packages/enterprise-search/src/api/enterprise/api.ts
@@ -70,6 +70,31 @@ export default class API {
     }, options)
   }
 
+  async getStorage (this: That, params?: T.GetStorageRequest, options?: TransportRequestOptions): Promise<T.GetStorageResponse> {
+    return await this.transport.request<T.GetStorageResponse>({
+      method: 'GET',
+      path: '/api/ent/v1/internal/storage'
+    }, options)
+  }
+
+  async getStaleStorage (this: That, params?: T.GetStaleStorageRequest, options?: TransportRequestOptions): Promise<T.GetStaleStorageResponse> {
+    return await this.transport.request<T.GetStaleStorageResponse>({
+      method: 'GET',
+      path: '/api/ent/v1/internal/storage/stale'
+    }, options)
+  }
+
+  async deleteStaleStorage (this: That, params?: T.DeleteStaleStorageRequest, options?: TransportRequestOptions): Promise<T.DeleteStaleStorageResponse> {
+    const {
+      ...querystring
+    } = params ?? {}
+    return await this.transport.request<T.DeleteStaleStorageResponse>({
+      method: 'DELETE',
+      path: '/api/ent/v1/internal/storage/stale',
+      querystring
+    }, options)
+  }
+
   async getVersion (this: That, params?: T.GetVersionRequest, options?: TransportRequestOptions): Promise<T.GetVersionResponse> {
     return await this.transport.request<T.GetVersionResponse>({
       method: 'GET',

--- a/packages/enterprise-search/src/api/enterprise/types.ts
+++ b/packages/enterprise-search/src/api/enterprise/types.ts
@@ -246,7 +246,48 @@ export interface GetStatsResponse {
       total_private_sources: number
       total_queries_last_30_days: number
     }
+    enterprise_search: {
+      total_search_indices: number
+    }
   }
+}
+
+export interface GetStorageRequest {}
+
+export interface GetStorageResponse {
+  indices: Array<{
+    name: string
+    size_in_bytes: number
+  }>
+  summary: {
+    index_count: number
+    size_in_bytes: number
+  }
+}
+
+export interface GetStaleStorageRequest {}
+
+export interface GetStaleStorageResponse {
+  indices: Array<{
+    name: string
+    size_in_bytes: number
+  }>
+  summary: {
+    index_count: number
+    size_in_bytes: number
+  }
+}
+
+export interface DeleteStaleStorageRequest {
+  /**
+   * The value for the "force" flag
+   */
+  force?: boolean
+}
+
+export interface DeleteStaleStorageResponse {
+  indices: string[]
+  index_count: number
 }
 
 export interface GetVersionRequest {}

--- a/packages/enterprise-search/src/api/workplace/types.ts
+++ b/packages/enterprise-search/src/api/workplace/types.ts
@@ -75,6 +75,9 @@ export interface CreateContentSourceRequest {
         }
       }
       default_action: 'include' | 'exclude'
+      /**
+       * @minItems 0
+       */
       rules?: Array<{
         exclude?: string
         include?: string
@@ -106,6 +109,9 @@ export interface CreateContentSourceRequest {
          * How often to update user permissions, as an ISO-8601 duration
          */
         permissions?: string
+        /**
+         * @minItems 0
+         */
         blocked_windows?: Array<{
           job_type: 'full' | 'incremental' | 'delete' | 'permissions' | 'all'
           day: 'all' | 'sunday' | 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday'
@@ -124,6 +130,9 @@ export interface CreateContentSourceRequest {
      * Facet customizations
      */
     facets?: {
+      /**
+       * @minItems 0
+       */
       overrides: Array<{
         field: string
         enabled: boolean
@@ -135,6 +144,9 @@ export interface CreateContentSourceRequest {
      * Automatic query refinement customizations
      */
     automatic_query_refinement?: {
+      /**
+       * @minItems 0
+       */
       overrides: Array<{
         field: string
         enabled: boolean
@@ -171,12 +183,16 @@ export interface CreateContentSourceResponse {
   is_remote: boolean
   /**
    * A list of key/value metadata for the Content Source and the account which authenticated/connected it.
+   *
+   * @minItems 0
    */
   details: Array<{
     [k: string]: unknown
   }>
   /**
    * A list of Workplace Search Group names and IDs which have access to this Content Source.
+   *
+   * @minItems 0
    */
   groups: Array<{
     id: string
@@ -232,6 +248,9 @@ export interface CreateContentSourceResponse {
       }
     }
     default_action: 'include' | 'exclude'
+    /**
+     * @minItems 0
+     */
     rules?: Array<{
       exclude?: string
       include?: string
@@ -263,6 +282,9 @@ export interface CreateContentSourceResponse {
        * How often to update user permissions, as an ISO-8601 duration
        */
       permissions?: string
+      /**
+       * @minItems 0
+       */
       blocked_windows?: Array<{
         job_type: 'full' | 'incremental' | 'delete' | 'permissions' | 'all'
         day: 'all' | 'sunday' | 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday'
@@ -342,6 +364,9 @@ export interface CreateContentSourceResponse {
    * Facet customizations
    */
   facets?: {
+    /**
+     * @minItems 0
+     */
     overrides: Array<{
       field: string
       enabled: boolean
@@ -353,6 +378,9 @@ export interface CreateContentSourceResponse {
    * Automatic query refinement customizations
    */
   automatic_query_refinement?: {
+    /**
+     * @minItems 0
+     */
     overrides: Array<{
       field: string
       enabled: boolean
@@ -415,12 +443,16 @@ export interface ListContentSourcesResponse {
     is_remote: boolean
     /**
      * A list of key/value metadata for the Content Source and the account which authenticated/connected it.
+     *
+     * @minItems 0
      */
     details: Array<{
       [k: string]: unknown
     }>
     /**
      * A list of Workplace Search Group names and IDs which have access to this Content Source.
+     *
+     * @minItems 0
      */
     groups: Array<{
       id: string
@@ -476,6 +508,9 @@ export interface ListContentSourcesResponse {
         }
       }
       default_action: 'include' | 'exclude'
+      /**
+       * @minItems 0
+       */
       rules?: Array<{
         exclude?: string
         include?: string
@@ -507,6 +542,9 @@ export interface ListContentSourcesResponse {
          * How often to update user permissions, as an ISO-8601 duration
          */
         permissions?: string
+        /**
+         * @minItems 0
+         */
         blocked_windows?: Array<{
           job_type: 'full' | 'incremental' | 'delete' | 'permissions' | 'all'
           day: 'all' | 'sunday' | 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday'
@@ -586,6 +624,9 @@ export interface ListContentSourcesResponse {
      * Facet customizations
      */
     facets?: {
+      /**
+       * @minItems 0
+       */
       overrides: Array<{
         field: string
         enabled: boolean
@@ -597,6 +638,9 @@ export interface ListContentSourcesResponse {
      * Automatic query refinement customizations
      */
     automatic_query_refinement?: {
+      /**
+       * @minItems 0
+       */
       overrides: Array<{
         field: string
         enabled: boolean
@@ -648,12 +692,16 @@ export interface GetContentSourceResponse {
   is_remote: boolean
   /**
    * A list of key/value metadata for the Content Source and the account which authenticated/connected it.
+   *
+   * @minItems 0
    */
   details: Array<{
     [k: string]: unknown
   }>
   /**
    * A list of Workplace Search Group names and IDs which have access to this Content Source.
+   *
+   * @minItems 0
    */
   groups: Array<{
     id: string
@@ -709,6 +757,9 @@ export interface GetContentSourceResponse {
       }
     }
     default_action: 'include' | 'exclude'
+    /**
+     * @minItems 0
+     */
     rules?: Array<{
       exclude?: string
       include?: string
@@ -740,6 +791,9 @@ export interface GetContentSourceResponse {
        * How often to update user permissions, as an ISO-8601 duration
        */
       permissions?: string
+      /**
+       * @minItems 0
+       */
       blocked_windows?: Array<{
         job_type: 'full' | 'incremental' | 'delete' | 'permissions' | 'all'
         day: 'all' | 'sunday' | 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday'
@@ -819,6 +873,9 @@ export interface GetContentSourceResponse {
    * Facet customizations
    */
   facets?: {
+    /**
+     * @minItems 0
+     */
     overrides: Array<{
       field: string
       enabled: boolean
@@ -830,6 +887,9 @@ export interface GetContentSourceResponse {
    * Automatic query refinement customizations
    */
   automatic_query_refinement?: {
+    /**
+     * @minItems 0
+     */
     overrides: Array<{
       field: string
       enabled: boolean
@@ -902,6 +962,9 @@ export interface PutContentSourceRequest {
         }
       }
       default_action: 'include' | 'exclude'
+      /**
+       * @minItems 0
+       */
       rules?: Array<{
         exclude?: string
         include?: string
@@ -933,6 +996,9 @@ export interface PutContentSourceRequest {
          * How often to update user permissions, as an ISO-8601 duration
          */
         permissions?: string
+        /**
+         * @minItems 0
+         */
         blocked_windows?: Array<{
           job_type: 'full' | 'incremental' | 'delete' | 'permissions' | 'all'
           day: 'all' | 'sunday' | 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday'
@@ -951,6 +1017,9 @@ export interface PutContentSourceRequest {
      * Facet customizations
      */
     facets?: {
+      /**
+       * @minItems 0
+       */
       overrides: Array<{
         field: string
         enabled: boolean
@@ -962,6 +1031,9 @@ export interface PutContentSourceRequest {
      * Automatic query refinement customizations
      */
     automatic_query_refinement?: {
+      /**
+       * @minItems 0
+       */
       overrides: Array<{
         field: string
         enabled: boolean
@@ -998,12 +1070,16 @@ export interface PutContentSourceResponse {
   is_remote: boolean
   /**
    * A list of key/value metadata for the Content Source and the account which authenticated/connected it.
+   *
+   * @minItems 0
    */
   details: Array<{
     [k: string]: unknown
   }>
   /**
    * A list of Workplace Search Group names and IDs which have access to this Content Source.
+   *
+   * @minItems 0
    */
   groups: Array<{
     id: string
@@ -1059,6 +1135,9 @@ export interface PutContentSourceResponse {
       }
     }
     default_action: 'include' | 'exclude'
+    /**
+     * @minItems 0
+     */
     rules?: Array<{
       exclude?: string
       include?: string
@@ -1090,6 +1169,9 @@ export interface PutContentSourceResponse {
        * How often to update user permissions, as an ISO-8601 duration
        */
       permissions?: string
+      /**
+       * @minItems 0
+       */
       blocked_windows?: Array<{
         job_type: 'full' | 'incremental' | 'delete' | 'permissions' | 'all'
         day: 'all' | 'sunday' | 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday'
@@ -1169,6 +1251,9 @@ export interface PutContentSourceResponse {
    * Facet customizations
    */
   facets?: {
+    /**
+     * @minItems 0
+     */
     overrides: Array<{
       field: string
       enabled: boolean
@@ -1180,6 +1265,9 @@ export interface PutContentSourceResponse {
    * Automatic query refinement customizations
    */
   automatic_query_refinement?: {
+    /**
+     * @minItems 0
+     */
     overrides: Array<{
       field: string
       enabled: boolean
@@ -1282,11 +1370,11 @@ export interface ListDocumentsRequest {
       | ((string | number) | Array<string | number>)
       | {
         /**
-             * A value to filter on
+             * The start of the range, inclusive
              */
         from?: string | number
         /**
-             * A value to filter on
+             * The end of the range, exclusive
              */
         to?: string | number
       }
@@ -1300,11 +1388,11 @@ export interface ListDocumentsRequest {
              */
         center: string | [number, number]
         /**
-             * A value to filter on
+             * Inclusive lower bound of the range. Is required if to is not provided
              */
         from?: string | number
         /**
-             * A value to filter on
+             * Exclusive upper bound of the range. Is required if from is not provided
              */
         to?: string | number
       }
@@ -1358,6 +1446,10 @@ export interface IndexDocumentsRequest {
    * Unique ID for a Custom API source, provided upon creation of a Custom API Source
    */
   content_source_id: string
+  /**
+   * @minItems 1
+   * @maxItems 100
+   */
   documents: Array<{
     [k: string]: unknown
   }>
@@ -1366,6 +1458,9 @@ export interface IndexDocumentsRequest {
 export interface IndexDocumentsResponse {
   results: Array<{
     id: string
+    /**
+     * @minItems 0
+     */
     errors: string[]
   }>
 }
@@ -1375,6 +1470,10 @@ export interface DeleteDocumentsRequest {
    * Unique ID for a Custom API source, provided upon creation of a Custom API Source
    */
   content_source_id: string
+  /**
+   * @minItems 1
+   * @maxItems 100
+   */
   document_ids: string[]
 }
 
@@ -1431,6 +1530,8 @@ export interface ListExternalIdentitiesResponse {
     external_user_id: string
     /**
      * List of external user properties
+     *
+     * @maxItems 1024
      */
     external_user_properties?: Array<{
       attribute_name: '_elasticsearch_username'
@@ -1455,6 +1556,9 @@ export interface CreateExternalIdentityRequest {
     external_user_id: string
     /**
      * A list of external user properties, where each property is an object with an attribute_name and attribute_value.
+     *
+     * @minItems 0
+     * @maxItems 1024
      */
     external_user_properties: Array<{
       attribute_name: '_elasticsearch_username'
@@ -1462,6 +1566,8 @@ export interface CreateExternalIdentityRequest {
     }>
     /**
      * A list of user permissions.
+     *
+     * @minItems 0
      */
     permissions: string[]
   }
@@ -1472,6 +1578,8 @@ export interface CreateExternalIdentityResponse {
   external_user_id: string
   /**
    * List of external user properties
+   *
+   * @maxItems 1024
    */
   external_user_properties?: Array<{
     attribute_name: '_elasticsearch_username'
@@ -1499,6 +1607,8 @@ export interface GetExternalIdentityResponse {
   external_user_id: string
   /**
    * List of external user properties
+   *
+   * @maxItems 1024
    */
   external_user_properties?: Array<{
     attribute_name: '_elasticsearch_username'
@@ -1526,6 +1636,9 @@ export interface PutExternalIdentityRequest {
     external_user_id: string
     /**
      * A list of external user properties, where each property is an object with an attribute_name and attribute_value.
+     *
+     * @minItems 0
+     * @maxItems 1024
      */
     external_user_properties?:
     | Array<{
@@ -1535,6 +1648,8 @@ export interface PutExternalIdentityRequest {
     | null
     /**
      * A list of user permissions.
+     *
+     * @minItems 0
      */
     permissions?: string[] | null
   }
@@ -1545,6 +1660,8 @@ export interface PutExternalIdentityResponse {
   external_user_id: string
   /**
    * List of external user properties
+   *
+   * @maxItems 1024
    */
   external_user_properties?: Array<{
     attribute_name: '_elasticsearch_username'
@@ -1651,6 +1768,8 @@ export interface PutSynonymSetRequest {
   body: {
     /**
      * A list of terms for this synonym set
+     *
+     * @minItems 2
      */
     synonyms: string[]
   }
@@ -1896,11 +2015,11 @@ export interface SearchRequest {
       | ((string | number) | Array<string | number>)
       | {
         /**
-             * A value to filter on
+             * The start of the range, inclusive
              */
         from?: string | number
         /**
-             * A value to filter on
+             * The end of the range, exclusive
              */
         to?: string | number
       }
@@ -1914,11 +2033,11 @@ export interface SearchRequest {
              */
         center: string | [number, number]
         /**
-             * A value to filter on
+             * Inclusive lower bound of the range. Is required if to is not provided
              */
         from?: string | number
         /**
-             * A value to filter on
+             * Exclusive upper bound of the range. Is required if from is not provided
              */
         to?: string | number
       }
@@ -1949,6 +2068,9 @@ export interface SearchRequest {
       | Array<| {
         type: 'range'
         name?: string
+        /**
+                 * @minItems 1
+                 */
         ranges: Array<| {
           [k: string]: unknown
         }
@@ -1974,6 +2096,9 @@ export interface SearchRequest {
         | {
           type: 'range'
           name?: string
+          /**
+                 * @minItems 1
+                 */
           ranges: Array<| {
             [k: string]: unknown
           }
@@ -2024,15 +2149,9 @@ export interface SearchRequest {
           [k: string]: unknown
         }
       )>
-      | ((
-        | {
-          [k: string]: unknown
-        }
-        | {
-          [k: string]: unknown
-        }
-      ) &
-      (
+      | ({
+        [k: string]: unknown
+      } & (
         | {
           [k: string]: unknown
         }
@@ -2040,9 +2159,7 @@ export interface SearchRequest {
           function: 'linear' | 'exponential' | 'logarithmic'
           [k: string]: unknown
         }
-      ) & {
-        [k: string]: unknown
-      })
+      ))
     }
     /**
      * Optional parameter to search standard, remote only, or all available sources
@@ -2054,6 +2171,8 @@ export interface SearchRequest {
     timeout?: number
     /**
      * Optional list of content source ids to only return results from
+     *
+     * @minItems 1
      */
     content_sources?: string[]
   }
@@ -2088,6 +2207,9 @@ export interface SearchResponse {
         term?: string
         /**
          * The start and end position the term(s) exist in the original query
+         *
+         * @minItems 2
+         * @maxItems 2
          */
         position?: number[]
         /**
@@ -2103,11 +2225,11 @@ export interface SearchResponse {
           | ((string | number) | Array<string | number>)
           | {
             /**
-                 * A value to filter on
+                 * The start of the range, inclusive
                  */
             from?: string | number
             /**
-                 * A value to filter on
+                 * The end of the range, exclusive
                  */
             to?: string | number
           }
@@ -2121,11 +2243,11 @@ export interface SearchResponse {
                  */
             center: string | string | string | [number, number]
             /**
-                 * A value to filter on
+                 * Inclusive lower bound of the range. Is required if to is not provided
                  */
             from?: string | number
             /**
-                 * A value to filter on
+                 * Exclusive upper bound of the range. Is required if from is not provided
                  */
             to?: string | number
           }


### PR DESCRIPTION
Updates APIs to include updates to the 8.6 spec.

Closes https://github.com/elastic/enterprise-search-js/issues/38