### PR TITLE
Change enterprise-search-frontend team to search-kibana team as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # For more info, see https://help.github.com/articles/about-codeowners/
 
 * @elastic/clients-team
-* @elastic/enterprise-search-frontend
+* @elastic/search-kibana


### PR DESCRIPTION
### Description
In order to prepare everything for archiving @elastic/enterprise-search-frontend team, it's required to update CODEOWNERS to point to the relevant team.

This PR is dedicated to replacing @elastic/enterprise-search-frontend with @elastic/search-kibana team