### PR TITLE
Rename the clients-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # Identify which groups will be pinged by changes to different parts of the codebase.
 # For more info, see https://help.github.com/articles/about-codeowners/
 
-* @elastic/clients-team
+* @elastic/devtools-team
 * @elastic/search-kibana


### PR DESCRIPTION
### Description
As part of the GitHub teams renaming initiative, it's required to replace the @elastic/clients-team with @elastic/devtools-team.

This PR is dedicated to renaming @elastic/clients-team to @elastic/devtools-team