### PR TITLE
docs: update security url to link to central policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -3,4 +3,4 @@ name: 👮 Security Issue
 about: Responsible Disclosure
 ---
 
-If you want to report a security issue, please take a look at [elastic/security](https://www.elastic.co/community/security).
+If you want to report a security issue, please take a look at [elastic/security](https://github.com/elastic/.github/blob/main/SECURITY.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Hello there!
 Thank you for opening a pull request!
 Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.
 
-If you are patching a security issue, please take a look at https://www.elastic.co/community/security
+If you are patching a security issue, please take a look at https://github.com/elastic/.github/blob/main/SECURITY.md
 
 Finally, please make sure you have signed the Contributor License Agreement
 We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.


### PR DESCRIPTION
This PR replaces security URLs with a link to the central security policy.