### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,10 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   backport:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds explicit `permissions:` block to `.github/workflows/backport.yml`
- `tibdex/backport` requires write access to contents and pull-requests

## Motivation

InfoSec is changing GITHUB_TOKEN default permissions from read/write to read-only on July 15th. This PR adds explicit permissions blocks to all workflows that require write access before that change takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)